### PR TITLE
order manager now accepts int and not a list

### DIFF
--- a/Bangazon.Tests/Bangazon_OrderManagerShould.cs
+++ b/Bangazon.Tests/Bangazon_OrderManagerShould.cs
@@ -38,8 +38,8 @@ namespace Bangazon.Tests
 
             int ProductID = 1;
             _om.CreateNewOrder(ProductID);
-            List<Order> customerOrders = _om.GetCustomerOrder(_currentCustomer.customerID);
-            Assert.IsType<List<Order>>(customerOrders);
+            Order customerOrders = _om.GetCustomerOrder(_currentCustomer.customerID);
+            Assert.IsType<int>(customerOrders);
         }
 
         //Get the current customer and create a new order

--- a/Bangazon.Tests/Bangazon_OrderManagerShould.cs
+++ b/Bangazon.Tests/Bangazon_OrderManagerShould.cs
@@ -39,7 +39,7 @@ namespace Bangazon.Tests
             int ProductID = 1;
             _om.CreateNewOrder(ProductID);
             Order customerOrders = _om.GetCustomerOrder(_currentCustomer.customerID);
-            Assert.IsType<int>(customerOrders);
+            Assert.IsType<Order>(customerOrders);
         }
 
         //Get the current customer and create a new order

--- a/Bangazon.Tests/Bangazon_OrderManagerShould.cs
+++ b/Bangazon.Tests/Bangazon_OrderManagerShould.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BangazonCLI;
+using BangazonCLI.MenuActions;
 using Xunit;
 
 namespace Bangazon.Tests
@@ -35,9 +36,7 @@ namespace Bangazon.Tests
             _currentCustomer.phoneNumber= "555-123-4567";
             CustomerManager.currentCustomer = _currentCustomer;
 
-            List<int> ProductID = new List<int>();
-            ProductID.Add(1);
-            ProductID.Add(2);
+            int ProductID = 1;
             _om.CreateNewOrder(ProductID);
             List<Order> customerOrders = _om.GetCustomerOrder(_currentCustomer.customerID);
             Assert.IsType<List<Order>>(customerOrders);
@@ -57,9 +56,7 @@ namespace Bangazon.Tests
             _currentCustomer.phoneNumber= "555-123-4567";
             CustomerManager.currentCustomer = _currentCustomer;
 
-            List<int> ProductID = new List<int>();
-            ProductID.Add(1);
-            ProductID.Add(2);
+            int ProductID = 1;
             var result = _om.CreateNewOrder(ProductID);
             Assert.IsType<int>(result);
         }
@@ -78,9 +75,7 @@ namespace Bangazon.Tests
             _currentCustomer.phoneNumber= "555-123-4567";
             CustomerManager.currentCustomer = _currentCustomer;
 
-            List<int> ProductID = new List<int>();
-            ProductID.Add(1);
-            ProductID.Add(2);
+            int ProductID = 1;
             _om.CreateNewOrder(ProductID);
             var result = _om.AddProductToOrder(ProductID);
             Assert.IsType<int>(result);

--- a/Bangazon/Managers/OrderManager.cs
+++ b/Bangazon/Managers/OrderManager.cs
@@ -18,18 +18,15 @@ using Microsoft.Data.Sqlite;
         }
 
         //Passing in the currentCustomerID, returns the currentCustomer order (object) 
-        public List<Order> GetCustomerOrder(int customerID)
+        public Order GetCustomerOrder(int customerID)
         {
-            List<Order> customerOrder = new List<Order>();
+            Order customerOrder = new Order();
             _db.Query($"SELECT * FROM `order` WHERE customerID = {customerID}", (SqliteDataReader reader) => {
-                customerOrder.Clear();
                 while (reader.Read())
                 {
-                    customerOrder.Add(new Order() {
-                        orderID = reader.GetInt32(0),
-                        customerID = reader.GetInt32(0),
-                        paymentTypeID = reader.GetInt32(0),
-                    });
+                    customerOrder.orderID = reader.GetInt32(0);
+                    customerOrder.customerID = reader.GetInt32(1);
+                    customerOrder.paymentTypeID = reader.GetInt32(2);
                 }
             });
             return customerOrder;
@@ -38,7 +35,7 @@ using Microsoft.Data.Sqlite;
         //Pass in product IDs of products to be added an order
         public int CreateNewOrder(int productID)
         {
-            int orderID = _db.Insert($"INSERT INTO `order` values (null, {CustomerManager.currentCustomer.customerID}, null)");
+            int orderID = _db.Insert($"INSERT INTO `order` values (null, {CustomerManager.currentCustomer.customerID}, null, '{DateTime.Now}')");
             _db.Insert($"INSERT INTO productOrder values (null, {productID}, {orderID})");
             return orderID;
         }

--- a/Bangazon/Managers/OrderManager.cs
+++ b/Bangazon/Managers/OrderManager.cs
@@ -26,7 +26,8 @@ using Microsoft.Data.Sqlite;
                 {
                     customerOrder.orderID = reader.GetInt32(0);
                     customerOrder.customerID = reader.GetInt32(1);
-                    customerOrder.paymentTypeID = reader.GetInt32(2);
+                    customerOrder.paymentTypeID = reader[2] as int? ?? null;
+                    customerOrder.dateCreated = reader.GetDateTime(3);
                 }
             });
             return customerOrder;

--- a/Bangazon/Managers/OrderManager.cs
+++ b/Bangazon/Managers/OrderManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 
     //Written by: Adam Reidelbach, Matt Augsburger
-    namespace BangazonCLI
+    namespace BangazonCLI.MenuActions
     {
         // Manages order related methods
         public class OrderManager
@@ -36,18 +36,15 @@ using Microsoft.Data.Sqlite;
         }
 
         //Pass in product IDs of products to be added an order
-        public int CreateNewOrder(List<int> productID)
+        public int CreateNewOrder(int productID)
         {
             int orderID = _db.Insert($"INSERT INTO `order` values (null, {CustomerManager.currentCustomer.customerID}, null)");
-            foreach(int id in productID)
-            {
-                _db.Insert($"INSERT INTO productOrder values (null, {id}, {orderID})");
-            }
+            _db.Insert($"INSERT INTO productOrder values (null, {productID}, {orderID})");
             return orderID;
         }
 
         // Adds a product to the active customer's order
-        public int AddProductToOrder(List<int> productID)
+        public int AddProductToOrder(int productID)
         {
             int customerID = CustomerManager.currentCustomer.customerID;
             _db.Query($"SELECT orderID FROM `order` WHERE customerID = {customerID} and paymentTypeID = null", (SqliteDataReader reader) => {
@@ -56,10 +53,7 @@ using Microsoft.Data.Sqlite;
                     _orderID = reader.GetInt32(0);
                 }
             });
-            foreach(int id in productID)
-            {
-                _db.Insert( $"insert into productOrder values (null, {id}, {_orderID})");
-            }
+            _db.Insert( $"insert into productOrder values (null, {productID}, {_orderID})");
             return _orderID;
         }
     }

--- a/Bangazon/MenuActions/AddProductOrder.cs
+++ b/Bangazon/MenuActions/AddProductOrder.cs
@@ -24,7 +24,14 @@ namespace BangazonCLI.MenuActions
 
             Product selectedProduct = products[index];
             om.AddProductToOrder(selectedProduct.productID);
-            
+
+            List<Product> newProducts = pm.GetProductList(custID);
+            foreach (Product product in newProducts)
+            {
+                Console.WriteLine($"{productCounter}. {product.name}");
+                productCounter++;
+            }
+
             // After the user selects a product to add to the customer's order, display the menu of products again. Make sure the last option provides the option to go back to main menu.
         }
     }

--- a/Bangazon/MenuActions/AddProductOrder.cs
+++ b/Bangazon/MenuActions/AddProductOrder.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace BangazonCLI.MenuActions
+    {
+    public class AddProductOrder
+    {
+        public static void AddProductToOrder(CustomerManager cm, dbUtilities db, ProductManager pm, OrderManager om)
+        {
+            int custID = CustomerManager.currentCustomer.customerID;
+            //Get a list of products
+            Console.WriteLine ("Choose a product to add to the order");
+            List<Product> products = pm.GetProductList(custID);
+            //Display the list of products
+            int productCounter = 1;
+            foreach (Product product in products)
+            {
+            Console.WriteLine($"{productCounter}. {product.name}");
+            productCounter++;
+            }
+            Console.WriteLine ("> ");
+            int choice = int.Parse(Console.ReadLine());
+            int index = choice -1;
+
+            Product selectedProduct = products[index];
+            om.AddProductToOrder(selectedProduct.productID);
+            
+            // After the user selects a product to add to the customer's order, display the menu of products again. Make sure the last option provides the option to go back to main menu.
+        }
+    }
+}

--- a/Bangazon/MenuActions/AddProductOrder.cs
+++ b/Bangazon/MenuActions/AddProductOrder.cs
@@ -7,6 +7,7 @@ namespace BangazonCLI.MenuActions
     {
         public static void AddProductToOrder(CustomerManager cm, dbUtilities db, ProductManager pm, OrderManager om)
         {
+            Console.Clear();
             int custID = CustomerManager.currentCustomer.customerID;
             //Get a list of products
             Console.WriteLine ("Choose a product to add to the order");
@@ -15,9 +16,10 @@ namespace BangazonCLI.MenuActions
             int productCounter = 1;
             foreach (Product product in products)
             {
-            Console.WriteLine($"{productCounter}. {product.name}");
-            productCounter++;
+                Console.WriteLine($"{productCounter}. {product.name}");
+                productCounter++;
             }
+            Console.WriteLine($"{productCounter}. Done Adding Products");
             Console.WriteLine ("> ");
             int choice = int.Parse(Console.ReadLine());
             int index = choice -1;
@@ -25,13 +27,8 @@ namespace BangazonCLI.MenuActions
             Product selectedProduct = products[index];
             om.AddProductToOrder(selectedProduct.productID);
 
-            List<Product> newProducts = pm.GetProductList(custID);
-            foreach (Product product in newProducts)
-            {
-                Console.WriteLine($"{productCounter}. {product.name}");
-                productCounter++;
-            }
-
+            
+            
             // After the user selects a product to add to the customer's order, display the menu of products again. Make sure the last option provides the option to go back to main menu.
         }
     }

--- a/Bangazon/Models/Order.cs
+++ b/Bangazon/Models/Order.cs
@@ -11,7 +11,7 @@ namespace BangazonCLI
     {
         public int orderID { get; set; }
         public int customerID { get; set; }
-        public int paymentTypeID { get; set; }
+        public int? paymentTypeID { get; set; }
         public DateTime dateCreated {get; set;}
         public List<Product> products { get; set; }
    }

--- a/Bangazon/Program.cs
+++ b/Bangazon/Program.cs
@@ -29,6 +29,7 @@ namespace BangazonCLI
 
             ProductManager pm = new ProductManager(db);
             ProductTypeManager ptm = new ProductTypeManager(db);
+            OrderManager om = new OrderManager(db);
 
 
 
@@ -63,6 +64,11 @@ namespace BangazonCLI
                         AddProductToSell.DoAction(pm, ptm);
                         break;
                     case 5:
+                    if (CustomerManager.currentCustomer == null)
+                        {
+                            ChooseCustomer.ChooseCustomerMenu(cm, db);
+                        }
+                        AddProductOrder.AddProductToOrder(cm, db, pm, om);
                         break;
                     case 6:
                         break;

--- a/Bangazon/dbSeed.sqlite.sql
+++ b/Bangazon/dbSeed.sqlite.sql
@@ -35,7 +35,7 @@ CREATE TABLE `productType`  (
 CREATE TABLE `order`        (
                             `orderID`	integer NOT NULL PRIMARY KEY AUTOINCREMENT,
                             `customerID`	integer not null,
-                            `paymentTypeID`	integer not null,
+                            `paymentTypeID`	integer,
                             `DateCreated`   varchar(80) not null,
                             FOREIGN KEY(`customerID`) REFERENCES `customer`(`id`),
                             FOREIGN KEY(`paymentTypeID`) REFERENCES `paymentType`(`id`)


### PR DESCRIPTION
## REFERENCE

Ticket (#5)

[ERD](https://github.com/Phat-Taupe-Pests/Bangazon) 

## DESCRIPTION
- Program.cs includes choice 5
- Still working on AddProductToOrder menu
- Removed list of ProductIDs in OrderManager and made it an int. 
- Same as above on OrderManager should. 
- GetCustomerOrder now returns a single order, dateCreated now included, paymentTypeID adjustment
- All tests but 1 should pass

## STEPS TO TEST
1. Clone this branch to a local repo
2. Run `dotnet restore`
3. Test functionality
        * delete your test DB if you have one
	* dotnet test
