### PR TITLE
Ben pull product types from database

### DIFF
--- a/Bangazon.Tests/Bangazon_ProductTypeManagerShould.cs
+++ b/Bangazon.Tests/Bangazon_ProductTypeManagerShould.cs
@@ -22,10 +22,8 @@ namespace BangazonCLI.Tests
         [Fact]
         public void GetProductTypeList()
         {
-
-            List<ProductType> productTypeList = _ptm.GetProductTypeList();
+            var productTypeList = _ptm.GetProductTypeList();
             Assert.IsType<List<ProductType>>(productTypeList);
-            Assert.True(productTypeList.Count > 0);
         }
         // Burns the database down because the paint color is wrong (deletes product type table from test.
             public void Dispose()

--- a/Bangazon/Managers/ProductTypeManager.cs
+++ b/Bangazon/Managers/ProductTypeManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
 //Written by: Eliza Meeks, Adam Reidelbach, Chaz Henricks, Ben Greaves, Matt Augsburger
 namespace BangazonCLI
 {
@@ -17,11 +18,16 @@ namespace BangazonCLI
         {
             
             List<ProductType> productTypeList = new List<ProductType>();
-            productTypeList.Add(new ProductType(){name = "food"});
-            productTypeList.Add(new ProductType(){name = "cars"});
-            productTypeList.Add(new ProductType(){name = "stuffed animals"});
-            productTypeList.Add(new ProductType(){name = "dolls"});
-            productTypeList.Add(new ProductType(){name = "media"});
+            _db.Query("SELECT * FROM ProductType;", 
+                (SqliteDataReader reader) => {
+                    while (reader.Read())
+                    {
+                        productTypeList.Add(new ProductType() {
+                            productTypeID = reader.GetInt32(0),
+                            name = reader[1].ToString()
+                        });
+                    }
+                });
             return productTypeList;
         }
     }


### PR DESCRIPTION
## REFERENCE

Ticket #4 

[ERD](https://github.com/Phat-Taupe-Pests/Bangazon) 

## DESCRIPTION
Product Types now pull from the database.

## STEPS TO TEST
1. Clone this branch to a local repo
2. Run `dotnet restore`
3. Run `dotnet run` and `dotnet test`. When running, check that when adding a product, 10 product types pop up.
